### PR TITLE
Fix invalid license in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -14,7 +14,7 @@
     "SuperMAIN": "lib/SuperMAIN.rakumod"
   },
   "resources": [],
-  "license": "Artistic License 2.0",
+  "license": "Artistic-2.0",
   "tags": [
     "MAIN",
     "parameters",


### PR DESCRIPTION
The license field should be a valid SPDX identifier as mentioned under https://docs.raku.org/language/modules#Preparing_the_module